### PR TITLE
Update docs, requirements and add basic outline test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This script follows a **source-first** workflow, attempting to gather informatio
 
 1.  **Run the Script:** Open a terminal or command prompt (a *new* one after setting environment variables or creating `.env`), navigate to the project directory, and run:
     ```bash
-    python DS_Deepresearch.py
+    python DS_Deepresearch_GUI/DS_Deepresearch_GUI.py
     ```
 2.  **Enter Topic:** Type your research topic into the "Research Topic" field in the GUI window that appears.
 3.  **Select Language:** Choose either "English" or "Chinese (简体)" using the radio buttons.
@@ -120,4 +120,22 @@ You can modify the following constants near the top of the script file:
 
 ## License
 
-Copyright 2025 Pengwei Zhu Permission is hereby granted, free of charge, to any person obtaining a copyof this software and associated documentation files (the "Software"), to dealin the Software without restriction, including without limitation the rightsto use, copy, modify, merge, publish, distribute, sublicense, and/or sellcopies of the Software, and to permit persons to whom the Software isfurnished to do so, subject to the following conditions:The above copyright notice and this permission notice shall be included in allcopies or substantial portions of the Software.THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS ORIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THEAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHERLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THESOFTWARE
+Copyright (c) 2025 Pengwei Zhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0
 python-dotenv>=1.0.0
+fastmcp>=0.1.0

--- a/tests/test_parse_outline.py
+++ b/tests/test_parse_outline.py
@@ -1,0 +1,24 @@
+import unittest
+import importlib.util
+import os
+import sys
+
+# Load the GUI module directly since it's not in a package
+module_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "DS_Deepresearch_GUI", "DS_Deepresearch_GUI.py")
+spec = importlib.util.spec_from_file_location("gui", module_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+parse_outline_sections = module.parse_outline_sections
+
+class TestParseOutlineSections(unittest.TestCase):
+    def test_standard_outline(self):
+        outline = """I. Introduction\nA. Background\nB. Methods\nII. Results"""
+        expected = ["I. Introduction", "A. Background", "B. Methods", "II. Results"]
+        self.assertEqual(parse_outline_sections(outline), expected)
+
+    def test_fallback_nonstandard(self):
+        outline = "Intro\nDetails\nConclusion"
+        self.assertEqual(parse_outline_sections(outline), ["Intro", "Details", "Conclusion"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document MIT license correctly and fix run command in README
- require `fastmcp` in requirements
- add simple unit tests for `parse_outline_sections`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b85308e7483289c7423f800177913